### PR TITLE
feat: rewrite concurrency manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "tsup": "^8.1.0",
     "typedoc": "^0.26.4",
     "typescript": "^5.5.3"
+  },
+  "dependencies": {
+    "fastify": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,5 @@
     "tsup": "^8.1.0",
     "typedoc": "^0.26.4",
     "typescript": "^5.5.3"
-  },
-  "dependencies": {
-    "fastify": "^5.2.0"
   }
 }

--- a/src/Indomitable.ts
+++ b/src/Indomitable.ts
@@ -232,9 +232,9 @@ export class Indomitable extends EventEmitter {
         }
         if (this.handleConcurrency) {
             const sessions = await this.fetchSessions();
-            this.concurrencyServer = new ConcurrencyServer(sessions.session_start_limit.max_concurrency);
+            this.concurrencyServer = new ConcurrencyServer(this, sessions.session_start_limit.max_concurrency);
             const info = await this.concurrencyServer.start();
-            this.emit(LibraryEvents.DEBUG, `Handle concurrency is currently enabled! => Server is currently bound to:\n  Address: ${info.address}:${info.port}\n  Concurrency: ${sessions.session_start_limit.max_concurrency}`);
+            this.emit(LibraryEvents.DEBUG, `Handle concurrency is currently enabled! =>\nServer is currently bound to:\n  Address: ${info.address}:${info.port}\n  Concurrency: ${sessions.session_start_limit.max_concurrency}`);
         }
         if (typeof this.clusterCount !== 'number')
             this.clusterCount = Os.cpus().length;

--- a/src/Indomitable.ts
+++ b/src/Indomitable.ts
@@ -3,7 +3,7 @@ import Cluster, { ClusterSettings } from 'node:cluster';
 import EventEmitter from 'node:events';
 import Os from 'node:os';
 import { clearTimeout } from 'timers';
-import { ConcurrencyManager } from './concurrency/ConcurrencyManager';
+import { ConcurrencyServer } from './concurrency/ConcurrencyServer';
 import { ShardClient } from './client/ShardClient';
 import { ClusterManager } from './manager/ClusterManager.js';
 import {
@@ -19,6 +19,7 @@ import {
     Transportable,
     Sendable
 } from './Util';
+
 
 /**
  * Options to control Indomitable behavior
@@ -143,7 +144,7 @@ export class Indomitable extends EventEmitter {
     public clusterCount: number|'auto';
     public shardCount: number|'auto';
     public cachedSession?: SessionObject;
-    public concurrencyManager?: ConcurrencyManager;
+    public concurrencyServer?: ConcurrencyServer;
     public readonly clientOptions: DiscordJsClientOptions;
     public readonly clusterSettings: ClusterSettings;
     public readonly ipcTimeout: number;
@@ -187,7 +188,7 @@ export class Indomitable extends EventEmitter {
         this.token = options.token;
         this.clusters = new Map();
         this.spawnQueue = [];
-        this.concurrencyManager = undefined;
+        this.concurrencyServer = undefined;
         this.cachedSession = undefined;
         this.busy = false;
     }
@@ -231,8 +232,9 @@ export class Indomitable extends EventEmitter {
         }
         if (this.handleConcurrency) {
             const sessions = await this.fetchSessions();
-            this.concurrencyManager = new ConcurrencyManager(sessions.session_start_limit.max_concurrency);
-            this.emit(LibraryEvents.DEBUG, 'Handle concurrency is currently enabled. Indomitable will automatically handle your identifies that can result to more stable connection');
+            this.concurrencyServer = new ConcurrencyServer(sessions.session_start_limit.max_concurrency);
+            const info = await this.concurrencyServer.start();
+            this.emit(LibraryEvents.DEBUG, `Handle concurrency is currently enabled! => Server is currently bound to:\n  Address: ${info.address}:${info.port}\n  Concurrency: ${sessions.session_start_limit.max_concurrency}`);
         }
         if (typeof this.clusterCount !== 'number')
             this.clusterCount = Os.cpus().length;

--- a/src/Indomitable.ts
+++ b/src/Indomitable.ts
@@ -234,7 +234,7 @@ export class Indomitable extends EventEmitter {
             const sessions = await this.fetchSessions();
             this.concurrencyServer = new ConcurrencyServer(this, sessions.session_start_limit.max_concurrency);
             const info = await this.concurrencyServer.start();
-            this.emit(LibraryEvents.DEBUG, `Handle concurrency is currently enabled! =>\nServer is currently bound to:\n  Address: ${info.address}:${info.port}\n  Concurrency: ${sessions.session_start_limit.max_concurrency}`);
+            this.emit(LibraryEvents.DEBUG, `Handle concurrency is currently enabled! =>\n  Server is currently bound to:\n    Address: ${info.address}:${info.port}\n    Concurrency: ${sessions.session_start_limit.max_concurrency}`);
         }
         if (typeof this.clusterCount !== 'number')
             this.clusterCount = Os.cpus().length;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -246,14 +246,14 @@ export function Fetch(url: string|URL, options: RequestOptions): Promise<FetchRe
  */
 export async function FetchSessions(token: string): Promise<SessionObject> {
     const url = new URL('https://discord.com/api/v10/gateway/bot');
-    const data = await Fetch(url, {
+    const response = await Fetch(url, {
         method: 'GET',
         headers: { authorization: `Bot ${token}` }
     });
-    if (data.code >= 200 && data.code <= 299)
-        return JSON.parse(data.body);
+    if (response.code >= 200 && response.code <= 299)
+        return JSON.parse(response.body);
     else
-        throw new Error(`Response received is not ok, code: ${data.code}`)
+        throw new Error(`Response received is not ok, code: ${response.code}`)
 }
 
 /**

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -227,10 +227,10 @@ export function Fetch(url: string, options: RequestOptions): Promise<FetchRespon
     return new Promise((resolve, reject) => {
         let client;
 
-        if (url.startsWith('http')) {
-            client = Http.request;
-        } else if (url.startsWith('https')) {
+        if (url.startsWith('https')) {
             client = Https.request;
+        } else if (url.startsWith('http')) {
+            client = Http.request;
         } else {
             throw new Error('Unknown url protocol');
         }

--- a/src/client/ShardClient.ts
+++ b/src/client/ShardClient.ts
@@ -21,7 +21,7 @@ export class ShardClient {
         clientOptions.shardCount = EnvProcessData.shardCount;
         if (manager.handleConcurrency) {
             if (!clientOptions.ws) clientOptions.ws = {};
-            clientOptions.ws.buildIdentifyThrottler = () => Promise.resolve(new ConcurrencyClient(new BaseWorker()));
+            clientOptions.ws.buildIdentifyThrottler = () => Promise.resolve(new ConcurrencyClient());
         }   
         this.client = new manager.client(clientOptions);
         // @ts-expect-error: Override shard client util with indomitable shard client util

--- a/src/concurrency/AsyncQueue.ts
+++ b/src/concurrency/AsyncQueue.ts
@@ -4,15 +4,8 @@ export declare interface AsyncQueueWaitOptions {
     signal?: AbortSignal | undefined;
 }
 
-export declare interface AsyncQueueEmitter extends EventEmitter {
-    emit(event: string, args?: unknown): this;
-    on(event: 'resolve', listener: (message: string) => void): this;
-    once(event: 'resolve', listener: (message: string) => void): this;
-    off(event: 'resolve', listener: (event: unknown) => void): this;
-}
-
 export class AsyncQueue {
-    private readonly queue: AsyncQueueEmitter[];
+    private readonly queue: EventEmitter[];
     constructor() {
         this.queue = [];
     }
@@ -25,7 +18,8 @@ export class AsyncQueue {
         // @ts-expect-error: this is ok
         const next = this.remaining ? once(this.queue[this.remaining - 1], 'resolve', { signal }) : Promise.resolve([]);
         
-        const emitter = new EventEmitter() as AsyncQueueEmitter;
+        const emitter = new EventEmitter();
+
         this.queue.push(emitter);
 
         if (signal) {
@@ -41,6 +35,7 @@ export class AsyncQueue {
 
     public shift(): void {
         const emitter = this.queue.shift();
+        // @ts-expect-error: emit exists in event emitter
         if (typeof emitter !== 'undefined') emitter.emit('resolve');
     }
 }

--- a/src/concurrency/AsyncQueue.ts
+++ b/src/concurrency/AsyncQueue.ts
@@ -5,13 +5,14 @@ export declare interface AsyncQueueWaitOptions {
 }
 
 export declare interface AsyncQueueEmitter extends EventEmitter {
+    emit(event: string, args?: unknown): this;
     on(event: 'resolve', listener: (message: string) => void): this;
     once(event: 'resolve', listener: (message: string) => void): this;
     off(event: 'resolve', listener: (event: unknown) => void): this;
 }
 
 export class AsyncQueue {
-    private queue: AsyncQueueEmitter[];
+    private readonly queue: AsyncQueueEmitter[];
     constructor() {
         this.queue = [];
     }
@@ -21,9 +22,10 @@ export class AsyncQueue {
     }
 
     public wait({ signal }: AsyncQueueWaitOptions): Promise<void[]> {
+        // @ts-expect-error: this is ok
         const next = this.remaining ? once(this.queue[this.remaining - 1], 'resolve', { signal }) : Promise.resolve([]);
         
-        const emitter: AsyncQueueEmitter = new EventEmitter();
+        const emitter = new EventEmitter() as AsyncQueueEmitter;
         this.queue.push(emitter);
 
         if (signal) {

--- a/src/concurrency/AsyncQueue.ts
+++ b/src/concurrency/AsyncQueue.ts
@@ -1,11 +1,11 @@
-import { EventEmitter, once } from 'events';
+import { EventEmitter, once } from 'node:events';
 
 export declare interface AsyncQueueWaitOptions {
     signal?: AbortSignal | undefined;
 }
 
 export class AsyncQueue {
-    private readonly queue: EventEmitter[];
+    private readonly queue: NodeJS.EventEmitter[];
     constructor() {
         this.queue = [];
     }
@@ -15,10 +15,10 @@ export class AsyncQueue {
     }
 
     public wait({ signal }: AsyncQueueWaitOptions): Promise<void[]> {
-        // @ts-expect-error: this is ok
+
         const next = this.remaining ? once(this.queue[this.remaining - 1], 'resolve', { signal }) : Promise.resolve([]);
         
-        const emitter = new EventEmitter();
+        const emitter = new EventEmitter() as NodeJS.EventEmitter;
 
         this.queue.push(emitter);
 
@@ -35,7 +35,7 @@ export class AsyncQueue {
 
     public shift(): void {
         const emitter = this.queue.shift();
-        // @ts-expect-error: emit exists in event emitter
+
         if (typeof emitter !== 'undefined') emitter.emit('resolve');
     }
 }

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -25,6 +25,7 @@ export class ConcurrencyServer {
      * @private
      */
     private readonly password: string;
+
     constructor(manager: Indomitable, concurrency: number) {
         this.manager = manager;
         this.server = Http.createServer((req, res) => this.handle(req, res));

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -1,6 +1,5 @@
 import { AddressInfo } from 'node:net';
 import { ConcurrencyManager } from './ConcurrencyManager';
-import { once } from 'node:events';
 import Http from 'node:http';
 
 /**
@@ -106,10 +105,8 @@ export class ConcurrencyServer {
      * Starts this server
      */
     public start(): Promise<AddressInfo> {
-        return new Promise((resolve, reject) => {
-            this.server.listen();
-            this.server.once('listening', () => resolve(this.info))
-            this.server.once('error', reject)
+        return new Promise((resolve) => {
+            this.server.listen(0 , () => resolve(this.info));
         })
     }
 }

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -83,7 +83,7 @@ export class ConcurrencyServer {
             return void response.end();
         }
 
-        if (request.method === 'DELETE' && request.url.includes('/concurrency/acquire')) {
+        if (request.method === 'POST' && request.url.includes('/concurrency/acquire')) {
             try {
                 await this.manager.waitForIdentify(shardId);
                 response.statusCode = 204;

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -1,8 +1,9 @@
 import { AddressInfo } from 'node:net';
 import { ConcurrencyManager } from './ConcurrencyManager';
 import { Indomitable } from '../Indomitable';
+import { LibraryEvents } from '../Util';
 import Http from 'node:http';
-import {LibraryEvents} from "../Util";
+import QueryString from 'node:querystring';
 
 /**
  * Server that handles identify locks
@@ -10,7 +11,7 @@ import {LibraryEvents} from "../Util";
 export class ConcurrencyServer {
     private readonly manager: Indomitable;
     /**
-     * Fastify instance of this server
+     * Http server of this instance
      * @private
      */
     private readonly server: Http.Server;
@@ -64,15 +65,13 @@ export class ConcurrencyServer {
             return void response.end();
         }
 
-        // @ts-expect-error: this is ok
-        if (!request.query.hasOwnProperty('shardId')) {
+        if (!request.url.includes('?shardId=')) {
             response.statusCode = 400;
             response.statusMessage = 'Bad Request';
             return void response.end('Missing shardId query string');
         }
 
-        // @ts-expect-error: this is ok
-        const shardId = Number(request.query['shardId']);
+        const shardId = Number(request.url.split('?shardId=')[1]);
 
         if (isNaN(shardId)) {
             response.statusCode = 400;

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -1,5 +1,6 @@
 import { AddressInfo } from 'node:net';
 import { ConcurrencyManager } from './ConcurrencyManager';
+import { once } from 'node:events';
 import Http from 'node:http';
 
 /**
@@ -106,10 +107,9 @@ export class ConcurrencyServer {
      */
     public start(): Promise<AddressInfo> {
         return new Promise((resolve, reject) => {
-            this.server.listen((error: Error, addressInfo: AddressInfo) => {
-                if (error) return reject(error);
-                resolve(addressInfo);
-            })
+            this.server.listen();
+            this.server.once('listening', () => resolve(this.info))
+            this.server.once('error', reject)
         })
     }
 }

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -87,7 +87,7 @@ export class ConcurrencyServer {
             try {
                 await this.manager.waitForIdentify(shardId);
                 response.statusCode = 204;
-                response.statusMessage = 'OK';
+                response.statusMessage = 'No Content';
                 return void response.end();
             } catch (error) {
                 response.statusCode = 202;

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -106,7 +106,7 @@ export class ConcurrencyServer {
      */
     public start(): Promise<AddressInfo> {
         return new Promise((resolve) => {
-            this.server.listen(0 , () => resolve(this.info));
+            this.server.listen(0 , '127.0.0.1', () => resolve(this.info));
         })
     }
 }

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -1,0 +1,107 @@
+import Fastify, { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { ConcurrencyManager } from './ConcurrencyManager';
+import { AddressInfo } from 'node:net';
+
+/**
+ * Server that handles identify locks
+ */
+export class ConcurrencyServer {
+    /**
+     * Fastify instance of this server
+     * @private
+     */
+    private readonly fastify: FastifyInstance;
+    /**
+     * Concurrency manager for this server
+     * @private
+     */
+    private readonly manager: ConcurrencyManager;
+    /**
+     * Randomly generated password to secure this server
+     * @private
+     */
+    private readonly password: string;
+    constructor(concurrency: number) {
+        this.fastify = Fastify();
+        this.manager = new ConcurrencyManager(concurrency);
+        this.password = Math.random().toString(36).slice(2, 10);
+
+        this.fastify.route({
+            method: 'POST',
+            url: '/concurrency/acquire',
+            handler: (req, res) => this.handle(req, res)
+        });
+
+        this.fastify.route({
+            method: 'DELETE',
+            url: '/concurrency/cancel',
+            handler: (req, res) => this.handle(req, res)
+        })
+    }
+
+    /**
+     * Gets the randomly generated password for this instance
+     */
+    public get key(): string {
+        return this.password;
+    }
+
+    /**
+     * Gets the address info assigned for this instance
+     */
+    public get info(): AddressInfo {
+        return this.fastify.addresses().filter(a => a.family === 'IPv4').shift()!;
+    }
+
+    /**
+     * Handles the incoming requests
+     * @param request
+     * @param reply
+     * @private
+     */
+    private async handle(request: FastifyRequest, reply: FastifyReply): Promise<string> {
+        if (request.headers['authorization'] !== this.password) {
+            reply.code(401);
+            return 'Unauthorized';
+        }
+
+        // @ts-expect-error: this is ok
+        if (!request.query.hasOwnProperty('shardId')) {
+            reply.code(400);
+            return 'Missing shardId query string';
+        }
+
+        // @ts-expect-error: this is ok
+        const shardId = Number(request.query['shardId']);
+
+        if (isNaN(shardId)) {
+            reply.code(400);
+            return 'Expected shardId to be a number';
+        }
+
+        if (request.url.includes('/concurrency/cancel')) {
+
+            this.manager.abortIdentify(shardId);
+
+        } else {
+            try {
+                await this.manager.waitForIdentify(shardId);
+            } catch (error) {
+                reply.code(202);
+                return 'Acquire lock cancelled';
+            }
+        }
+
+        reply.code(204);
+
+        return '';
+    }
+
+    /**
+     * Starts this server
+     */
+    public async start(): Promise<AddressInfo> {
+        await this.fastify.listen();
+        return this.fastify.addresses().filter(a => a.family === 'IPv4').shift()!;
+    }
+}

--- a/src/concurrency/ConcurrencyServer.ts
+++ b/src/concurrency/ConcurrencyServer.ts
@@ -38,7 +38,7 @@ export class ConcurrencyServer {
      * Gets the address info assigned for this instance
      */
     public get info(): AddressInfo {
-        return this.server.address as unknown as AddressInfo;
+        return this.server.address() as AddressInfo;
     }
 
     /**

--- a/src/ipc/MainWorker.ts
+++ b/src/ipc/MainWorker.ts
@@ -58,13 +58,6 @@ export class MainWorker extends BaseIpc {
                     message.reply(manager.cachedSession);
                     break;
                 }
-                case InternalOps.REQUEST_IDENTIFY:
-                    await manager.concurrencyManager!.waitForIdentify(content.data.shardId);
-                    message.reply(null);
-                    break;
-                case InternalOps.CANCEL_IDENTIFY:
-                    manager.concurrencyManager!.abortIdentify(content.data.shardId);
-                    break;
                 case InternalOps.RESTART:
                     await manager.restart(content.data.clusterId);
                     break;

--- a/src/manager/ClusterManager.ts
+++ b/src/manager/ClusterManager.ts
@@ -73,6 +73,9 @@ export class ClusterManager {
             INDOMITABLE_SHARDS_TOTAL: this.manager.shardCount.toString(),
             INDOMITABLE_CLUSTER: this.id.toString(),
             INDOMITABLE_CLUSTER_TOTAL: this.manager.clusterCount.toString(),
+            INDOMITABLE_CONCURRENCY_SERVER_ADDRESS: this.manager.concurrencyServer?.info.address,
+            INDOMITABLE_CONCURRENCY_SERVER_PORT: this.manager.concurrencyServer?.info.port,
+            INDOMITABLE_CONCURRENCY_SERVER_PASSWORD: this.manager.concurrencyServer?.key,
             ...process.env
         });
         this.worker


### PR DESCRIPTION
The current implementation may cause issues (shards becoming unresponsive for some reason), so I decided to fully move the concurrency handling into a small server. 

I may also need to implement something that allows me to close the shard when the http req fails, avoiding a deadlock situation.

And lastly, may just ditch the fastify and use raw http but we'll see.